### PR TITLE
My implementation of the cut macro

### DIFF
--- a/ercf_additional.cfg
+++ b/ercf_additional.cfg
@@ -1,0 +1,147 @@
+[gcode_macro CUT_FILAMENT]
+description: Cut filament by pressing the cutter on a fixed pin with a horizontal movement. 
+
+# Distance to retract prior to making the cut, this reduces wasted filament but might cause clog 
+# if set too large and/or if there are gaps in the hotend assembly 
+# This must be less than the distance from the nozzle to the cutter.
+variable_retract_length: 35
+
+# The location of the pin, this should be the position of the toolhead when the cutter 
+# just lightly touches the pin
+variable_pin_loc_x: 20
+variable_pin_loc_y: 21.0
+
+# The starting and end positions when making the cut
+# In particular, instead of making the cut by traveling to the pin location above, 
+# we leave a small safety margin along X-axis to avoid scratching on the pin when traveling
+# This should also give a small distance to produce some momentum when pressing on the pin 
+variable_pin_park_x_dist: 5
+
+# Position of the toolhead when the cutter is fully compressed
+# Should leave a small headroom to avoid banging the toolhead or gantry
+variable_pin_loc_x_compressed: 5
+
+# Speed related settings
+# Note that if the cut speed is too fast, the steppers can lose steps
+# Therefore, for a cut: 
+# - We first make a fast move to accumulate some momentum and get the cut blade to the initial contact with the filament
+# - We then make a slow move for the actual cut to happen 
+variable_travel_spd: 7800
+variable_cut_fast_move_spd: 2000
+variable_cut_slow_move_spd: 500
+variable_evacuate_speed: 7800
+variable_cut_dwell_time: 200 ; time to dwell at the cut point in ms
+variable_cut_fast_move_fraction: 0.5 ; fraction of the move that uses fast move 
+
+# Safety margin for fast vs slow travel
+# When traveling to the pin location, we make a safer but longer move if we closer to the pin than this specified margin
+# Usually setting these to the size of the toolhead (plus a small margin) should be good enough 
+variable_safe_margin_x: 30
+variable_safe_margin_y: 30
+
+# Number of repeats for the cut
+# Better be one to avoid small debris due to different cutting positions for different tries 
+variable_num_cut_repeats: 1
+
+# Whether to eject the filament at the end
+variable_final_eject: 0
+
+# Currently ERCF software assumes that tip forming move always moves the extruder (and consequently the encoder)
+# Ideally, we should bring formal support of filament cutters to the ERCF software
+# In the short term, we perform a "hack" where we wiggle the extruder a little after cutting, 
+# if the extruder did not make enough movement during the filament cutting phase.
+variable_extruder_minimum_movement: 0 ; the minimum extruder movement required for this tip forming move, this depends on the minimum distance that the encoder can reliably detect
+                                      ; setting it to a lower value requires the ERCF encoder to be more sensitive.
+variable_extruder_wiggle_length: 10 ; the length to retract -> extrude during a wiggle, this needs to be large enough for the encoder to detect the movement
+variable_extruder_wiggle_repeat: 3 ; number of repeats for the wiggle
+
+# State variables
+variable_retracted_length_: 0 ; a state variable to keep track of how much we have retracted during the last cut, this is useful for restoring the filament position
+
+gcode:
+    {% set RETRACT_LENGTH = params.RETRACT_LENGTH | default(printer['gcode_macro CUT_FILAMENT']['retract_length']) | float %}
+    {% set FINAL_EJECT = params.FINAL_EJECT | default(printer['gcode_macro CUT_FILAMENT']['final_eject'], True) | int %}
+    {% set NUM_CUT_REPEATS = params.NUM_CUT_REPEATS | default(printer['gcode_macro CUT_FILAMENT']['num_cut_repeats']) | int%}
+    {% set current_loc_x = printer.gcode_move.gcode_position.x %}
+    {% set current_loc_y = printer.gcode_move.gcode_position.y %}
+
+    SAVE_GCODE_STATE NAME=cut_filament_state
+    
+    {% if ("x" not in printer.toolhead.homed_axes) or ("y" not in printer.toolhead.homed_axes) %}
+        G28 X Y
+    {% endif %}
+
+    {% set prev_pa = printer.extruder.pressure_advance %}
+    SET_PRESSURE_ADVANCE ADVANCE=0 ; temporaily disable PA
+
+    {% set pin_park_x_loc = pin_loc_x + pin_park_x_dist %}
+    {% set pin_park_y_loc = pin_loc_y %}
+    {% set _extruder_moved_dist = 0 %}
+
+    M83 ; relative extrusion
+    {% if RETRACT_LENGTH > 0 %}
+        G1 E-{RETRACT_LENGTH} F3000 ; retract to save filament waste
+        {% set _extruder_moved_dist = _extruder_moved_dist + RETRACT_LENGTH %}
+    {% endif %}
+    SET_GCODE_VARIABLE macro=CUT_FILAMENT variable=retracted_length_ value={RETRACT_LENGTH}
+
+    G90 ; absolute positioning
+    _MOVE_TO_CUTTER_PIN PIN_PARK_X_LOC={pin_park_x_loc} PIN_PARK_Y_LOC={pin_park_y_loc}
+
+    {% set fast_slow_transition_loc = (pin_loc_x_compressed - pin_park_x_loc) * cut_fast_move_fraction + pin_park_x_loc | float %}
+    {% for _ in range(NUM_CUT_REPEATS) %}
+        G1 X{fast_slow_transition_loc} F{cut_fast_move_spd} ; make a fast move to initiate contact of the blade with the filament
+        G1 X{pin_loc_x_compressed} F{cut_slow_move_spd} ; do the cut in slow move
+        G4 P{cut_dwell_time}
+        G1 X{pin_park_x_loc} F{evacuate_speed} ; evacuate
+    {% endfor %}
+
+    {% if FINAL_EJECT == 1 %}
+        G1 E-80 F3000
+        {% set _extruder_moved_dist = _extruder_moved_dist + 80 %}
+    {% endif %}
+
+    {% if _extruder_moved_dist < extruder_minimum_movement %}
+        # make some wiggle moves so that the encoder catch them
+        {% for _ in range(extruder_wiggle_repeat) %}
+            G1 E-{extruder_wiggle_length} F3000
+            G1 E{extruder_wiggle_length} F3000
+        {% endfor %}
+    {% endif %}
+
+    SET_PRESSURE_ADVANCE ADVANCE={prev_pa} ; restore PA
+    RESTORE_GCODE_STATE NAME=cut_filament_state
+
+[gcode_macro _MOVE_TO_CUTTER_PIN]
+description: helper to move the toolhead to the target pin in either safe or faster way, depending on toolhead clearance.
+gcode:
+    {% set safe_margin_x = printer['gcode_macro CUT_FILAMENT']['safe_margin_x'] | float %}
+    {% set safe_margin_y = printer['gcode_macro CUT_FILAMENT']['safe_margin_y'] | float %}
+    {% set travel_spd = printer['gcode_macro CUT_FILAMENT']['travel_spd'] | float %}
+    {% set pin_park_x_loc = params.PIN_PARK_X_LOC | float %}
+    {% set pin_park_y_loc = params.PIN_PARK_Y_LOC | float %}
+
+    G90 ; absolute positioning
+    {% if ((printer.gcode_move.gcode_position.x - pin_park_x_loc) | abs < safe_margin_x) or ((printer.gcode_move.gcode_position.y - pin_park_y_loc | float) | abs < safe_margin_y) %}
+        # Make a safe but slower travel move
+        G1 X{pin_park_x_loc} F{travel_spd}
+        G1 Y{pin_park_y_loc} F{travel_spd}
+    {% else %}
+        G1 X{pin_park_x_loc} Y{pin_park_y_loc} F{travel_spd}
+    {% endif %}
+
+[gcode_macro restore_cutted_filament]
+description: extrudes an amount equal (or proportional) to the retraction during the last cut
+gcode:
+    SAVE_GCODE_STATE NAME=restore_cutted_filament_state
+    {% set RETRACTED_LENGTH = printer['gcode_macro CUT_FILAMENT']['retracted_length_'] | float %}
+    M83 ; relative extrusion
+    G1 E{RETRACT_LENGTH} F3000
+    SET_GCODE_VARIABLE macro=CUT_FILAMENT variable=retracted_length_ value=0 ; clear the retracted amount
+    RESTORE_GCODE_STATE NAME=restore_cutted_filament_state
+
+
+[gcode_macro _ERCF_FORM_TIP_STANDALONE]
+gcode:
+    CUT_FILAMENT {rawparams}
+

--- a/ercf_additional.cfg
+++ b/ercf_additional.cfg
@@ -8,18 +8,18 @@ variable_retract_length: 35
 
 # The location of the pin, this should be the position of the toolhead when the cutter 
 # just lightly touches the pin
-variable_pin_loc_x: 20
-variable_pin_loc_y: 21.0
+variable_pin_loc_x: 21
+variable_pin_loc_y: 19
 
 # The starting and end positions when making the cut
 # In particular, instead of making the cut by traveling to the pin location above, 
 # we leave a small safety margin along X-axis to avoid scratching on the pin when traveling
 # This should also give a small distance to produce some momentum when pressing on the pin 
-variable_pin_park_x_dist: 5
+variable_pin_park_x_dist: 5.0
 
 # Position of the toolhead when the cutter is fully compressed
 # Should leave a small headroom to avoid banging the toolhead or gantry
-variable_pin_loc_x_compressed: 5
+variable_pin_loc_x_compressed: 5.0
 
 # Speed related settings
 # Note that if the cut speed is too fast, the steppers can lose steps
@@ -39,9 +39,12 @@ variable_cut_fast_move_fraction: 0.5 ; fraction of the move that uses fast move
 variable_safe_margin_x: 30
 variable_safe_margin_y: 30
 
-# Number of repeats for the cut
-# Better be one to avoid small debris due to different cutting positions for different tries 
-variable_num_cut_repeats: 1
+# Whether or not to make a second cut
+# The goal of the second cut is to avoid filament adding friction to the blade causing the lever unable to decompress
+# If set to a positive value, we first retract this amount, make the second cut, then extrude back
+# Set to 0 to disable to second cut
+# You should only enable this if you cannot get the lever to reliabily decompress.
+variable_second_cut_retract_length: 0
 
 # Whether to eject the filament at the end
 variable_final_eject: 0
@@ -61,7 +64,6 @@ variable_retracted_length_: 0 ; a state variable to keep track of how much we ha
 gcode:
     {% set RETRACT_LENGTH = params.RETRACT_LENGTH | default(printer['gcode_macro CUT_FILAMENT']['retract_length']) | float %}
     {% set FINAL_EJECT = params.FINAL_EJECT | default(printer['gcode_macro CUT_FILAMENT']['final_eject'], True) | int %}
-    {% set NUM_CUT_REPEATS = params.NUM_CUT_REPEATS | default(printer['gcode_macro CUT_FILAMENT']['num_cut_repeats']) | int%}
     {% set current_loc_x = printer.gcode_move.gcode_position.x %}
     {% set current_loc_y = printer.gcode_move.gcode_position.y %}
 
@@ -88,13 +90,14 @@ gcode:
     G90 ; absolute positioning
     _MOVE_TO_CUTTER_PIN PIN_PARK_X_LOC={pin_park_x_loc} PIN_PARK_Y_LOC={pin_park_y_loc}
 
-    {% set fast_slow_transition_loc = (pin_loc_x_compressed - pin_park_x_loc) * cut_fast_move_fraction + pin_park_x_loc | float %}
-    {% for _ in range(NUM_CUT_REPEATS) %}
-        G1 X{fast_slow_transition_loc} F{cut_fast_move_spd} ; make a fast move to initiate contact of the blade with the filament
-        G1 X{pin_loc_x_compressed} F{cut_slow_move_spd} ; do the cut in slow move
-        G4 P{cut_dwell_time}
-        G1 X{pin_park_x_loc} F{evacuate_speed} ; evacuate
-    {% endfor %}
+    # Make the main cut 
+    _DO_CUT_MOTION PIN_PARK_X_LOC={pin_park_x_loc}
+    # Optional secondary cut to help decompressing the lever
+    {% if second_cut_retract_length > 0 %}
+        G1 E-{second_cut_retract_length} F3000
+        _DO_CUT_MOTION PIN_PARK_X_LOC={pin_park_x_loc}
+        G1 E{second_cut_retract_length} F3000
+    {% endif %}
 
     {% if FINAL_EJECT == 1 %}
         G1 E-80 F3000
@@ -130,13 +133,29 @@ gcode:
         G1 X{pin_park_x_loc} Y{pin_park_y_loc} F{travel_spd}
     {% endif %}
 
+[gcode_macro _DO_CUT_MOTION]
+description: helper to do a single horizontal cut movement
+gcode:
+    {% set pin_loc_x_compressed = printer['gcode_macro CUT_FILAMENT']['pin_loc_x_compressed'] | float %}
+    {% set cut_fast_move_fraction = printer['gcode_macro CUT_FILAMENT']['cut_fast_move_fraction'] | float %}
+    {% set cut_fast_move_spd = printer['gcode_macro CUT_FILAMENT']['cut_fast_move_spd'] | float %}
+    {% set cut_slow_move_spd = printer['gcode_macro CUT_FILAMENT']['cut_slow_move_spd'] | float %}
+    {% set cut_dwell_time = printer['gcode_macro CUT_FILAMENT']['cut_dwell_time'] | float %}
+    {% set evacuate_speed = printer['gcode_macro CUT_FILAMENT']['evacuate_speed'] | float %}
+    {% set pin_park_x_loc = params.PIN_PARK_X_LOC | float %}
+    {% set fast_slow_transition_loc = (pin_loc_x_compressed - pin_park_x_loc) * cut_fast_move_fraction + pin_park_x_loc | float %}
+    G1 X{fast_slow_transition_loc} F{cut_fast_move_spd} ; make a fast move to initiate contact of the blade with the filament
+    G1 X{pin_loc_x_compressed} F{cut_slow_move_spd} ; do the cut in slow move
+    G4 P{cut_dwell_time}
+    G1 X{pin_park_x_loc} F{evacuate_speed} ; evacuate
+
 [gcode_macro restore_cutted_filament]
 description: extrudes an amount equal (or proportional) to the retraction during the last cut
 gcode:
     SAVE_GCODE_STATE NAME=restore_cutted_filament_state
     {% set RETRACTED_LENGTH = printer['gcode_macro CUT_FILAMENT']['retracted_length_'] | float %}
     M83 ; relative extrusion
-    G1 E{RETRACT_LENGTH} F3000
+    G1 E{RETRACTED_LENGTH} F3000
     SET_GCODE_VARIABLE macro=CUT_FILAMENT variable=retracted_length_ value=0 ; clear the retracted amount
     RESTORE_GCODE_STATE NAME=restore_cutted_filament_state
 
@@ -144,4 +163,3 @@ gcode:
 [gcode_macro _ERCF_FORM_TIP_STANDALONE]
 gcode:
     CUT_FILAMENT {rawparams}
-

--- a/ercf_additional.cfg
+++ b/ercf_additional.cfg
@@ -30,8 +30,8 @@ variable_travel_spd: 7800
 variable_cut_fast_move_spd: 2000
 variable_cut_slow_move_spd: 500
 variable_evacuate_speed: 7800
-variable_cut_dwell_time: 200 ; time to dwell at the cut point in ms
-variable_cut_fast_move_fraction: 0.5 ; fraction of the move that uses fast move 
+variable_cut_dwell_time: 200 # time to dwell at the cut point in ms
+variable_cut_fast_move_fraction: 0.5 # fraction of the move that uses fast move 
 
 # Safety margin for fast vs slow travel
 # When traveling to the pin location, we make a safer but longer move if we closer to the pin than this specified margin
@@ -53,13 +53,13 @@ variable_final_eject: 0
 # Ideally, we should bring formal support of filament cutters to the ERCF software
 # In the short term, we perform a "hack" where we wiggle the extruder a little after cutting, 
 # if the extruder did not make enough movement during the filament cutting phase.
-variable_extruder_minimum_movement: 0 ; the minimum extruder movement required for this tip forming move, this depends on the minimum distance that the encoder can reliably detect
-                                      ; setting it to a lower value requires the ERCF encoder to be more sensitive.
-variable_extruder_wiggle_length: 10 ; the length to retract -> extrude during a wiggle, this needs to be large enough for the encoder to detect the movement
-variable_extruder_wiggle_repeat: 3 ; number of repeats for the wiggle
+variable_extruder_minimum_movement: 0 # the minimum extruder movement required for this tip forming move, this depends on the minimum distance that the encoder can reliably detect
+                                      # setting it to a lower value requires the ERCF encoder to be more sensitive.
+variable_extruder_wiggle_length: 10 # the length to retract -> extrude during a wiggle, this needs to be large enough for the encoder to detect the movement
+variable_extruder_wiggle_repeat: 3 # number of repeats for the wiggle
 
 # State variables
-variable_retracted_length_: 0 ; a state variable to keep track of how much we have retracted during the last cut, this is useful for restoring the filament position
+variable_retracted_length_: 0 # a state variable to keep track of how much we have retracted during the last cut, this is useful for restoring the filament position
 
 gcode:
     {% set RETRACT_LENGTH = params.RETRACT_LENGTH | default(printer['gcode_macro CUT_FILAMENT']['retract_length']) | float %}
@@ -74,20 +74,20 @@ gcode:
     {% endif %}
 
     {% set prev_pa = printer.extruder.pressure_advance %}
-    SET_PRESSURE_ADVANCE ADVANCE=0 ; temporaily disable PA
+    SET_PRESSURE_ADVANCE ADVANCE=0 # temporaily disable PA
 
     {% set pin_park_x_loc = pin_loc_x + pin_park_x_dist %}
     {% set pin_park_y_loc = pin_loc_y %}
     {% set _extruder_moved_dist = 0 %}
 
-    M83 ; relative extrusion
+    M83 # relative extrusion
     {% if RETRACT_LENGTH > 0 %}
-        G1 E-{RETRACT_LENGTH} F3000 ; retract to save filament waste
+        G1 E-{RETRACT_LENGTH} F3000 # retract to save filament waste
         {% set _extruder_moved_dist = _extruder_moved_dist + RETRACT_LENGTH %}
     {% endif %}
     SET_GCODE_VARIABLE macro=CUT_FILAMENT variable=retracted_length_ value={RETRACT_LENGTH}
 
-    G90 ; absolute positioning
+    G90 # absolute positioning
     _MOVE_TO_CUTTER_PIN PIN_PARK_X_LOC={pin_park_x_loc} PIN_PARK_Y_LOC={pin_park_y_loc}
 
     # Make the main cut 
@@ -112,7 +112,7 @@ gcode:
         {% endfor %}
     {% endif %}
 
-    SET_PRESSURE_ADVANCE ADVANCE={prev_pa} ; restore PA
+    SET_PRESSURE_ADVANCE ADVANCE={prev_pa} # restore PA
     RESTORE_GCODE_STATE NAME=cut_filament_state
 
 [gcode_macro _MOVE_TO_CUTTER_PIN]
@@ -124,7 +124,7 @@ gcode:
     {% set pin_park_x_loc = params.PIN_PARK_X_LOC | float %}
     {% set pin_park_y_loc = params.PIN_PARK_Y_LOC | float %}
 
-    G90 ; absolute positioning
+    G90 # absolute positioning
     {% if ((printer.gcode_move.gcode_position.x - pin_park_x_loc) | abs < safe_margin_x) or ((printer.gcode_move.gcode_position.y - pin_park_y_loc | float) | abs < safe_margin_y) %}
         # Make a safe but slower travel move
         G1 X{pin_park_x_loc} F{travel_spd}
@@ -144,22 +144,23 @@ gcode:
     {% set evacuate_speed = printer['gcode_macro CUT_FILAMENT']['evacuate_speed'] | float %}
     {% set pin_park_x_loc = params.PIN_PARK_X_LOC | float %}
     {% set fast_slow_transition_loc = (pin_loc_x_compressed - pin_park_x_loc) * cut_fast_move_fraction + pin_park_x_loc | float %}
-    G1 X{fast_slow_transition_loc} F{cut_fast_move_spd} ; make a fast move to initiate contact of the blade with the filament
-    G1 X{pin_loc_x_compressed} F{cut_slow_move_spd} ; do the cut in slow move
+    G1 X{fast_slow_transition_loc} F{cut_fast_move_spd} # make a fast move to initiate contact of the blade with the filament
+    G1 X{pin_loc_x_compressed} F{cut_slow_move_spd} # do the cut in slow move
     G4 P{cut_dwell_time}
-    G1 X{pin_park_x_loc} F{evacuate_speed} ; evacuate
+    G1 X{pin_park_x_loc} F{evacuate_speed} # evacuate
 
 [gcode_macro restore_cutted_filament]
 description: extrudes an amount equal (or proportional) to the retraction during the last cut
 gcode:
     SAVE_GCODE_STATE NAME=restore_cutted_filament_state
     {% set RETRACTED_LENGTH = printer['gcode_macro CUT_FILAMENT']['retracted_length_'] | float %}
-    M83 ; relative extrusion
+    M83 # relative extrusion
     G1 E{RETRACTED_LENGTH} F3000
-    SET_GCODE_VARIABLE macro=CUT_FILAMENT variable=retracted_length_ value=0 ; clear the retracted amount
+    SET_GCODE_VARIABLE macro=CUT_FILAMENT variable=retracted_length_ value=0 # clear the retracted amount
     RESTORE_GCODE_STATE NAME=restore_cutted_filament_state
 
 
 [gcode_macro _ERCF_FORM_TIP_STANDALONE]
 gcode:
     CUT_FILAMENT {rawparams}
+


### PR DESCRIPTION
Hi,

This is my attempt at replacing the cut macro.

There are several places of the macro in the README that are insufficient. The most prominent one is that current Happy Hare software assumes that the tip forming always moves the encoder. But without the initial retraction for saving wasted filament, a cutter shall not move the encoder.

This also comes with features like auto homing, clearance avoidance etc. Let me know what you think