### PR TITLE
Happy Hare v2.0 Support

### DIFF
--- a/ercf_additional.cfg
+++ b/ercf_additional.cfg
@@ -161,6 +161,12 @@ gcode:
 
 
 [gcode_macro _ERCF_FORM_TIP_STANDALONE]
+description: helper to form tip with Happy Hare v1.1
+gcode:
+    CUT_FILAMENT {rawparams}
+
+[gcode_macro _MMU_FORM_TIP_STANDALONE]
+description: helper to form tip with Happy Hare v2.0
 gcode:
     CUT_FILAMENT {rawparams}
 


### PR DESCRIPTION
This commit adds a GCODE macro override for the new macro names for Happy Hare v2.0. 

Tested with `force_form_tip_standalone: 1` in `mmu/base/mmu_parameters.cfg`.

Closes #14 